### PR TITLE
Fix dtype inconsistency

### DIFF
--- a/nodes/omini_kontext_pipeline.py
+++ b/nodes/omini_kontext_pipeline.py
@@ -142,8 +142,9 @@ class OminiKontextSplitPipelineLoaderNode:
             CLIPTextConfig(**read_json(os.path.join(current_dir, "configs/text_encoder/config.json")))
         )
         clip_model.load_state_dict(load_file(clip_path))
+        clip_model = clip_model.to(dtype=self.dtype)
         clip_tokenizer = CLIPTokenizer.from_pretrained(os.path.join(current_dir, "configs/tokenizer"))
-
+        
         if auto_t5_gguf:
             t5_model = T5EncoderModel.from_pretrained(
                 "calcuis/kontext-gguf",
@@ -155,20 +156,23 @@ class OminiKontextSplitPipelineLoaderNode:
                 T5Config(**read_json(os.path.join(current_dir, "configs/text_encoder_2/config.json")))
             )
             t5_model.load_state_dict(load_file(t5_path), strict=False)
+            t5_model = t5_model.to(dtype=self.dtype)
         t5_tokenizer = T5TokenizerFast.from_pretrained(os.path.join(current_dir, "configs/tokenizer_2"))
 
         vae_model = AutoencoderKL(
             **read_json(os.path.join(current_dir, "configs/vae/config.json"))
         )
         vae_model.load_state_dict(load_file(vae_path))
+        vae_model = vae_model.to(dtype=self.dtype)
 
         if transformer_path.endswith('.safetensors') or transformer_path.endswith('.sft'):
             transformer_model = FluxTransformer2DModel(
                 **read_json(os.path.join(current_dir, "configs/transformer/config.json"))
             )
             transformer_model.load_state_dict(
-                load_file(transformer_path, dtype=self.dtype)
+                load_file(transformer_path)
             )
+            transformer_model = transformer_model.to(dtype=self.dtype)
         elif transformer_path.endswith('.gguf'):
             from diffusers import GGUFQuantizationConfig
 

--- a/nodes/omini_kontext_pipeline.py
+++ b/nodes/omini_kontext_pipeline.py
@@ -148,7 +148,7 @@ class OminiKontextSplitPipelineLoaderNode:
             t5_model = T5EncoderModel.from_pretrained(
                 "calcuis/kontext-gguf",
                 gguf_file="t5xxl_fp16-q4_0.gguf",
-                torch_dtype=torch.bfloat16,
+                torch_dtype=self.dtype,
             )
         else:
             t5_model = T5EncoderModel(


### PR DESCRIPTION
Minor fix
- [x] - Convert weights to the same dtype

---

Tested with VRAM 16 GB (5060 Ti) with the following config
- Transformers: `calcuis/kontext-gguf` -> `flux1-kontext-dev-f32-q2_k.gguf`
- CLIP: `calcuis/kontext-gguf` -> `text_encoder/model.safetensors`
- T5 (auto load): `calcuis/kontext-gguf` -> `t5xxl_fp32-q4_0.gguf`
- VAE: `calcuis/kontext-gguf` -> `vae/diffusion_pytorch_model.safetensors`

Peak VRAM
- `15.653Gi / 15.929Gi` - But occasionally OOM, so still recommend 20, or 24 GB of VRAM